### PR TITLE
small changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:6.1
-
 //
 // This source file is part of the Stanford Spezi open-source project
 // 

--- a/Sources/SpeziConsent/Views/ConsentSignatureForm.swift
+++ b/Sources/SpeziConsent/Views/ConsentSignatureForm.swift
@@ -41,12 +41,6 @@ public struct ConsentSignatureForm: View {
                 }
                 #endif
             }
-            .onChange(of: storage.name) {
-                if !storage.didEnterNames {
-                    // Reset all strokes if name fields are not complete anymore
-                    self.storage.clearSignature()
-                }
-            }
             Divider()
                 .id(dividerId)
         }

--- a/Sources/SpeziConsent/Views/SignatureView.swift
+++ b/Sources/SpeziConsent/Views/SignatureView.swift
@@ -93,8 +93,7 @@ public struct SignatureView: View {
     private var signatureCanvas: some View {
         CanvasView(
             drawing: $signature,
-            isDrawing: $isSigning,
-            showToolPicker: .constant(false)
+            isDrawing: $isSigning
         )
         .accessibilityLabel(Text("SIGNATURE_FIELD", bundle: .module))
         .accessibilityAddTraits(.allowsDirectInteraction)

--- a/Tests/UITests/TestApp/Consent/RenderedConsentDocumentView.swift
+++ b/Tests/UITests/TestApp/Consent/RenderedConsentDocumentView.swift
@@ -61,7 +61,7 @@ struct RenderedConsentDocumentView: View {
     }
     
     @ViewBuilder
-    private func content(for exportResult: ConsentDocument.ExportResult) -> some View {
+    private func content(for exportResult: ConsentDocument.ExportResult) -> some View { // swiftlint:disable:this function_body_length
         Section {
             if exportResult.pdf.pageCount > 0 {
                 Label {

--- a/Tests/UITests/TestApp/Consent/RenderedConsentDocumentView.swift
+++ b/Tests/UITests/TestApp/Consent/RenderedConsentDocumentView.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+import QuickLook
 import SpeziConsent
 import SpeziOnboarding
 import SpeziViews
@@ -19,55 +20,14 @@ struct RenderedConsentDocumentView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(ManagedNavigationStack.Path.self) private var path: ManagedNavigationStack.Path?
     @Environment(TestAppConsentStorage.self) private var consentStorage
+    @State private var viewState: ViewState = .idle
     @State private var exportResult: ConsentDocument.ExportResult?
+    @State private var quickLookUrl: URL?
     
     var body: some View {
-        Form { // swiftlint:disable:this closure_body_length
+        Form {
             if let exportResult, exportResult.pdf.pageCount > 0 {
-                Label {
-                    Text("\(docId.title) PDF rendering exists")
-                } icon: {
-                    Image(systemName: "checkmark")
-                        .foregroundStyle(.green)
-                        .accessibilityHidden(true)
-                }
-                if !exportResult.userResponses.toggles.isEmpty {
-                    Section("Toggles") {
-                        ForEach(Array(exportResult.userResponses.toggles.keys), id: \.self) { toggleId in
-                            let value = exportResult.userResponses.toggles[toggleId]! // swiftlint:disable:this force_unwrapping
-                            LabeledContent(toggleId, value: value.description)
-                        }
-                    }
-                }
-                if !exportResult.userResponses.selects.isEmpty {
-                    Section("Selects") {
-                        ForEach(Array(exportResult.userResponses.selects.keys), id: \.self) { selectId in
-                            let value = exportResult.userResponses.selects[selectId]! // swiftlint:disable:this force_unwrapping
-                            LabeledContent(selectId, value: value)
-                        }
-                    }
-                }
-                if !exportResult.userResponses.signatures.isEmpty {
-                    ForEach(Array(exportResult.userResponses.signatures.keys), id: \.self) { (signatureId: String) in
-                        Section("Signature: '\(signatureId)'") {
-                            let value = exportResult.userResponses.signatures[signatureId]! // swiftlint:disable:this force_unwrapping
-                            LabeledContent("Name", value: value.name.formatted())
-                            LabeledContent("Signature") {
-                                #if os(iOS)
-                                let scale: CGFloat = UIScreen.main.scale
-                                #else
-                                let scale: CGFloat = 3
-                                #endif
-                                let image = value.signature.image(from: value.signature.bounds, scale: scale)
-                                Image(uiImage: image)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 200)
-                                    .accessibilityLabel("Signature Drawing")
-                            }
-                        }
-                    }
-                }
+                content(for: exportResult)
             } else {
                 Label {
                     Text("\(docId.title) PDF rendering doesn't exist")
@@ -78,6 +38,7 @@ struct RenderedConsentDocumentView: View {
                 }
             }
         }
+        .viewStateAlert(state: $viewState)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button("Next") {
@@ -95,6 +56,77 @@ struct RenderedConsentDocumentView: View {
         .task {
             // Read and then clean up the respective exported consent document from the `ExampleStandard`
             exportResult = consentStorage.exportResults[docId].take()
+        }
+        .quickLookPreview($quickLookUrl)
+    }
+    
+    @ViewBuilder
+    private func content(for exportResult: ConsentDocument.ExportResult) -> some View {
+        Section {
+            if exportResult.pdf.pageCount > 0 {
+                Label {
+                    Text("\(docId.title) PDF rendering exists")
+                } icon: {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.green)
+                        .accessibilityHidden(true)
+                }
+                AsyncButton("Show PDF", state: $viewState) {
+                    let tmpUrl = URL.temporaryDirectory.appendingPathComponent(UUID().uuidString, conformingTo: .pdf)
+                    guard let data = exportResult.pdf.dataRepresentation() else {
+                        throw NSError(domain: "edu.stanford.SpeziConsent", code: 0, userInfo: [
+                            NSLocalizedDescriptionKey: "Unable to obtain PDF data"
+                        ])
+                    }
+                    try data.write(to: tmpUrl)
+                    quickLookUrl = tmpUrl
+                }
+            } else {
+                Label {
+                    Text("\(docId.title) PDF rendering doesn't exist")
+                } icon: {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(.red)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+        if !exportResult.userResponses.toggles.isEmpty {
+            Section("Toggles") {
+                ForEach(Array(exportResult.userResponses.toggles.keys), id: \.self) { toggleId in
+                    let value = exportResult.userResponses.toggles[toggleId]! // swiftlint:disable:this force_unwrapping
+                    LabeledContent(toggleId, value: value.description)
+                }
+            }
+        }
+        if !exportResult.userResponses.selects.isEmpty {
+            Section("Selects") {
+                ForEach(Array(exportResult.userResponses.selects.keys), id: \.self) { selectId in
+                    let value = exportResult.userResponses.selects[selectId]! // swiftlint:disable:this force_unwrapping
+                    LabeledContent(selectId, value: value)
+                }
+            }
+        }
+        if !exportResult.userResponses.signatures.isEmpty {
+            ForEach(Array(exportResult.userResponses.signatures.keys), id: \.self) { (signatureId: String) in
+                Section("Signature: '\(signatureId)'") {
+                    let value = exportResult.userResponses.signatures[signatureId]! // swiftlint:disable:this force_unwrapping
+                    LabeledContent("Name", value: value.name.formatted())
+                    LabeledContent("Signature") {
+                        #if os(iOS)
+                        let scale: CGFloat = UIScreen.main.scale
+                        #else
+                        let scale: CGFloat = 3
+                        #endif
+                        let image = value.signature.image(from: value.signature.bounds, scale: scale)
+                        Image(uiImage: image)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 200)
+                            .accessibilityLabel("Signature Drawing")
+                    }
+                }
+            }
         }
     }
 }

--- a/Tests/UITests/TestAppUITests/XCUIApplication+Consent.swift
+++ b/Tests/UITests/TestAppUITests/XCUIApplication+Consent.swift
@@ -10,27 +10,18 @@ import XCTest
 import XCTestExtensions
 
 extension XCUIApplication {
-//    func hitConsentButton() {
-//        if staticTexts["This is the first markdown example"].isHittable {
-//            staticTexts["This is the first markdown example"].swipeUp()
-//        } else if staticTexts["This is the second markdown example"].isHittable {
-//            staticTexts["This is the second markdown example"].swipeUp()
-//        } else {
-//            print("Can not scroll down.")
-//        }
-//        XCTAssert(buttons["I Consent"].waitForExistence(timeout: 2))
-//        buttons["I Consent"].tap()
-//    }
-    
-    
     func fillOutSimpleConsent(
         consentTitle: String,
         consentText: String,
         continueButton: XCUIElement
     ) throws {
+        func assertContinueButtonEnabledState(_ isEnabled: Bool) {
+            XCTAssert(continueButton.wait(for: \.isEnabled, toEqual: isEnabled, timeout: 2))
+        }
+        
         XCTAssert(staticTexts[consentTitle].waitForExistence(timeout: 2))
         XCTAssert(staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", consentText)).element.waitForExistence(timeout: 1))
-        XCTAssertFalse(continueButton.isEnabled)
+        assertContinueButtonEnabledState(false)
 
         #if targetEnvironment(simulator) && (arch(i386) || arch(x86_64))
         throw XCTSkip("PKCanvas view-related tests are currently skipped on Intel-based iOS simulators due to a metal bug on the simulator.")
@@ -38,10 +29,10 @@ extension XCUIApplication {
 
         XCTAssert(staticTexts["First Name"].waitForExistence(timeout: 2))
         try textFields["Enter your first name…"].enter(value: "Leland")
-        XCTAssertFalse(continueButton.isEnabled)
+        assertContinueButtonEnabledState(false)
         XCTAssert(staticTexts["Last Name"].waitForExistence(timeout: 2))
         try textFields["Enter your last name…"].enter(value: "Stanford")
-        XCTAssertFalse(continueButton.isEnabled)
+        assertContinueButtonEnabledState(false)
         
         XCTAssert(staticTexts["Name: Leland Stanford"].waitForExistence(timeout: 2))
 
@@ -49,31 +40,31 @@ extension XCUIApplication {
         XCTAssert(buttons["Clear"].waitForExistence(timeout: 2.0))
         XCTAssertFalse(buttons["Clear"].isEnabled)
         
-        XCTAssertFalse(continueButton.isEnabled)
+        assertContinueButtonEnabledState(false)
         staticTexts["Name: Leland Stanford"].swipeRight()
-        XCTAssert(continueButton.isEnabled)
+        assertContinueButtonEnabledState(true)
         
         XCTAssert(buttons["Clear"].waitForExistence(timeout: 2.0))
         XCTAssert(buttons["Clear"].isEnabled)
         buttons["Clear"].tap()
-        XCTAssertFalse(continueButton.isEnabled)
+        assertContinueButtonEnabledState(false)
         
         XCTAssert(buttons["Clear"].waitForExistence(timeout: 2.0))
         XCTAssertFalse(buttons["Clear"].isEnabled)
         
         XCTAssert(scrollViews["Signature Field"].waitForExistence(timeout: 2))
         scrollViews["Signature Field"].swipeRight()
-        XCTAssert(continueButton.isEnabled)
+        assertContinueButtonEnabledState(true)
         
         XCTAssert(buttons["Clear"].waitForExistence(timeout: 2.0))
         XCTAssert(buttons["Clear"].isEnabled)
-        XCTAssert(continueButton.isEnabled)
+        assertContinueButtonEnabledState(true)
         #else
         XCTAssert(textFields["Signature Field"].waitForExistence(timeout: 2))
         try textFields["Signature Field"].enter(value: "Leland Stanford")
         #endif
         
-        XCTAssert(continueButton.isEnabled)
+        assertContinueButtonEnabledState(true)
         continueButton.tap()
     }
     


### PR DESCRIPTION
# small changes


## :gear: Release Notes
- removed: SpeziConsent no longer resets the signature drawing if the name is edited and becomes an empty string


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF preview capability for rendered consent documents

* **Improvements**
  * Refined signature field behavior to prevent unintended clearing during name entry updates
  * Updated signature field tool picker display behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->